### PR TITLE
Documenting padding behavior for components.

### DIFF
--- a/src/design/Basics.js
+++ b/src/design/Basics.js
@@ -132,6 +132,61 @@ var Basics = React.createClass({
         </section>
 
         <section>
+          <a className="anchor" id="padding"></a>
+          <h2>Padding</h2>
+
+          <p>Padding on elements is based off of multiples and fractions of 24px. This value is used for line height, sizing, padding and margins on objects, etc.</p>
+
+          <h3>Padding and sizing on components</h3>
+
+          <p>Many components expose sizing and padding via <code>size</code> and <code>pad</code> attributes. For example, <code>Header</code> accepts <code>small</code>, <code>medium</code> and <code>large</code> as <code>size</code> attributes, which sets the height of the <code>Header</code> component to 48px, 72px, or 96px, respectively.
+          </p>
+
+          <p>
+            Components that accept the <code>size</code> attribute include:
+
+            <ul>
+              <li><code>Chart</code></li>
+              <li><code>Distribution</code></li>
+              <li><code>Footer</code></li>
+              <li><code>Header</code></li>
+              <li><code>Image</code> (<code>small</code> and <code>large</code> only. <code>small</code> = 240px; <code>large</code> = 960px)</li>
+              <li><code>List</code></li>
+              <li><code>Menu</code></li>
+              <li><code>Meter</code></li>
+              <li><code>Search</code> (<code>medium</code> and <code>large</code> only)</li>
+              <li><code>Sidebar</code> (<code>small</code> = 240px; <code>medium</code> = 336px; <code>large</code> = 360px)</li>
+              <li><code>Status</code> (<code>small</code> = 12px; <code>medium</code> = 24px; <code>large</code> = 48px)</li>
+              <li><code>Tile</code> (<code>small</code> = 96px; <code>medium</code> = 192px; <code>large</code> = 384px)</li>
+              <li><code>Video</code> (<code>small</code> = 240px; <code>medium</code> = 480px; <code>large</code> = 960px)</li>
+            </ul>
+          </p>
+
+          <p>
+            Components that accept the <code>pad</code> attribute include:
+
+            <ul>
+              <li><code>Article</code></li>
+              <li><code>Box</code></li>
+              <li><code>Footer</code></li>
+              <li><code>Form</code> (all <code>pad</code> attributes available, except for <code>between</code>)</li>
+              <li><code>Header</code></li>
+              <li><code>ListItem (in List)</code></li>
+              <li><code>Menu</code></li>
+              <li><code>Section</code></li>
+              <li><code>Sidebar</code></li>
+              <li><code>Tiles/Tile</code></li>
+            </ul>
+
+            For the <code>pad</code> attribute, <code>small</code> = 12px, <code>medium</code> = 24px, and <code>large</code> = 48px.
+          </p>
+
+          <p>
+            The <code>pad</code> attribute can be set to <code>small</code>, <code>medium</code>, or <code>large</code>, or an object which affects the padding of components horizontally, vertically, or in-between multiple components: <code>{"{horizontal: none|small|medium|large, vertical: none|small|medium|large, between: none|small|medium|large}"}</code>. Padding set using <code>between</code> only affects components based on the direction set (adds horizontal padding between components for <code>row</code>, or vertical padding between components for <code>column</code>).
+          </p>
+        </section>
+
+        <section>
           <a className="anchor" id="text"></a>
           <h2>Text</h2>
           <p>Text and Typography is arguably one of the most important elements of

--- a/src/design/Design.js
+++ b/src/design/Design.js
@@ -31,6 +31,7 @@ var CONTENTS = [
   {route: "design_basics", label: 'Basics', component: Basics,
     contents: [
       {label: 'Color', id: 'color'},
+      {label: 'Padding', id: 'padding'},
       {label: 'Text', id: 'text'},
       {label: 'Typography', id: 'typography'},
       {label: 'Writing Style', id: 'writing-style'},

--- a/src/develop/components/BoxDoc.js
+++ b/src/develop/components/BoxDoc.js
@@ -40,10 +40,14 @@ var BoxDoc = React.createClass({
             <dt><code>justify      start|center|between|end</code></dt>
             <dd>How to align the contents along the main axis.</dd>
             <dt><code>pad          {"none|small|medium|large|{...}"}</code></dt>
-            <dd>The amount of padding to put around the contents. An object
-              can be specified to distinguish horizontal and vertical padding: <code>
-              {"{horizontal: none|small|medium|large, vertical: none|small|medium|large}"}
-            </code>. Defaults to <code>none</code>.</dd>
+            <dd>The amount of padding to put around the contents.
+              An object can be specified to distinguish horizontal padding, vertical padding, and padding between child components: <code>
+              {"{horizontal: none|small|medium|large, vertical: none|small|medium|large, between: none|small|medium|large}"}
+              </code>. Defaults to <code>none</code>.
+              Padding set using <code>between</code> only affects components based on the direction set
+              (adds horizontal padding between components for <code>row</code>,
+              or vertical padding between components for <code>column</code>).
+            </dd>
             <dt><code>reverse      true|false</code></dt>
             <dd>Whether to reverse the order of the child components.</dd>
             <dt><code>responsive   true|false</code></dt>

--- a/src/develop/components/FormDoc.js
+++ b/src/develop/components/FormDoc.js
@@ -42,6 +42,12 @@ var FormDoc = React.createClass({
           <dd>Whether to render the form in a compact style.</dd>
           <dt><code>onSubmit  {"{func}"}</code></dt>
           <dd>A function called when the user submits the form.</dd>
+          <dt><code>pad       {"none|small|medium|large|{...}"}</code></dt>
+          <dd>The amount of padding to put around the contents.
+            An object can be specified to distinguish horizontal and vertical padding: <code>
+            {"{horizontal: none|small|medium|large, vertical: none|small|medium|large}"}
+            </code>. Defaults to <code>none</code>.
+          </dd>
           </dl>
         </section>
 


### PR DESCRIPTION
[https://trello.com/c/TE6jrPbi](https://trello.com/c/TE6jrPbi)

Added additional information to [Ivan's original pull request](https://github.com/grommet/grommet-docs/pull/8).

Updating padding instructions for Design Basics, updating BoxDoc pad information to include between, and updating FormDoc to include pad attribute.
