### PR TITLE
Updated NPM version in the Get Started section. Starting from NPM 3+ …

### DIFF
--- a/src/develop/GetStarted.js
+++ b/src/develop/GetStarted.js
@@ -30,7 +30,7 @@ class GetStarted extends Component {
             </li>
             <li>
               Install <a href="https://nodejs.org/" target="_blank">Node.js
-            </a> <i>(at least Node 4.4.x+ and NPM 2.14.x+ required)</i>
+            </a> <i>(at least Node 4.4.x+ and NPM 3.0.x+ required)</i>
             </li>
             <li>
               Install <a href="https://www.python.org/downloads/"


### PR DESCRIPTION
Hi Grommet Team,

I´ve adjusted the doc in order to solve the 'Could not find preset es2015 relative to directory error' which happens when you follow the Get Started section and use NPM <3. Please see also https://slack-redir.net/link?url=https%3A%2F%2Fgithub.com%2Fgrommet%2Fgrommet%2Fissues%2F477.

Kind regards,
Paolo
