### PR TITLE
Add npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
   },
   "scripts": {
     "build": "gulp dist",
+    "dev": "gulp dev",
+    "alias": "gulp dev --useAlias",
     "start": "node server/server.js"
   }
 }


### PR DESCRIPTION
Add npm scripts for `gulp dev` & `gulp dev --useAlias`. This way gulp doesn't need to be installed globally. 😄 
