### PR TITLE
Adding Tiles masonry and numColumns options + example to TilesDoc

### DIFF
--- a/src/docs/Example.js
+++ b/src/docs/Example.js
@@ -18,7 +18,7 @@ export default class Example extends Component {
   }
 
   render () {
-    const { align, code, control, name, preamble } = this.props;
+    const { align, full, code, control, name, preamble } = this.props;
     let heading;
     if (name) {
       heading = <h3>{name}</h3>;
@@ -32,7 +32,7 @@ export default class Example extends Component {
     }
 
     return (
-      <Box flex={true}>
+      <Box full={full} flex={true}>
         {heading}
         <Box pad={{ between: 'medium' }} align={align}>
           {control || code}
@@ -54,5 +54,6 @@ Example.propTypes = {
   control: PropTypes.node, // for LayerDoc
   name: PropTypes.string,
   overrides: PropTypes.arrayOf(PropTypes.string),
-  preamble: PropTypes.string
+  preamble: PropTypes.string,
+  full: PropTypes.oneOf([true, 'horizontal', 'vertical', false])
 };

--- a/src/docs/components/TilesDoc.js
+++ b/src/docs/components/TilesDoc.js
@@ -43,6 +43,14 @@ export default class TileDoc extends Component {
             <dt><code>size        small|medium|large</code></dt>
             <dd>The width of the contained tiles.
               Defaults to <code>medium</code>.</dd>
+            <dt><code>masonry     true|false</code></dt>
+            <dd>Whether to update the number of columns based on the component
+              width. Defaults to <code>false</code>. The number of columns can
+              be set with <code>numColumns</code>.</dd>
+            <dt><code>numColumns  number</code></dt>
+            <dd>Number of columns to allow for masonry option, based on
+              component width. Responds based on the width of the tile children
+              (set with <code>size</code>).</dd>
           </dl>
           <p>Options for <NavAnchor path="/docs/box">Box</NavAnchor> are
           also available for Tiles.</p>

--- a/src/docs/components/tiles/examples/Tiles8.js
+++ b/src/docs/components/tiles/examples/Tiles8.js
@@ -1,0 +1,20 @@
+// (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
+
+import React, { Component } from 'react';
+import Tiles from 'grommet/components/Tiles';
+import Example from '../../../Example';
+import { renderRichTiles } from './utils';
+
+export default class Tiles8 extends Component {
+
+  render () {
+    return (
+      <Example align="center" full="horizontal" code={
+        <Tiles masonry={true} numColumns={4} selectable={true}>
+          {renderRichTiles({alternateContent: true})}
+        </Tiles>
+      } />
+    );
+  }
+
+};

--- a/src/docs/components/tiles/examples/TilesExamplesDoc.js
+++ b/src/docs/components/tiles/examples/TilesExamplesDoc.js
@@ -18,6 +18,7 @@ import Tiles4 from './Tiles4';
 import Tiles5 from './Tiles5';
 import Tiles6 from './Tiles6';
 import Tiles7 from './Tiles7';
+import Tiles8 from './Tiles8';
 
 const TILES = [
   { label: 'Simple', component: Tiles1 },
@@ -26,7 +27,8 @@ const TILES = [
   { label: 'Fill, Flush', component: Tiles4 },
   { label: 'Row', component: Tiles5 },
   { label: 'Single Select', component: Tiles6 },
-  { label: 'Multiple Select', component: Tiles7 }
+  { label: 'Multiple Select', component: Tiles7 },
+  { label: 'Masonry, 4 Columns', component: Tiles8 }
 ];
 
 export default class TilesExamplesDoc extends Component {

--- a/src/docs/components/tiles/examples/utils.js
+++ b/src/docs/components/tiles/examples/utils.js
@@ -45,7 +45,10 @@ export function renderRichTiles (options={}, onClick) {
           <strong>{"Tile " + index}</strong>
         </Header>
         <Box pad="small">
-          <p>Tile summary content. One or two lines.</p>
+          <p>{(options.alternateContent && index % 2 === 0) ?
+            'Tile summary content. One or two lines.' :
+            'Tile summary content. One or two lines. Tile summary content.\
+            One or two lines.'}</p>
         </Box>
         {bottom}
       </Tile>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
#### What does this PR do?
- adding alternateContent option in tiles utils.js for masonry example with varying tile heights
- adding Tiles8.js (masonry example)
- updating TilesDoc with masonry and numColumns options
- passing in full props to Example.js to fix non-resizing Article content container (for Tiles masonry example)
#### What are the relevant issues?

For Tiles PR: https://github.com/grommet/grommet/pull/717
#### Screenshots (if appropriate)

![screen shot 2016-08-05 at 3 08 16 pm](https://cloud.githubusercontent.com/assets/10161095/17453818/81a4440c-5b1e-11e6-8b4f-de4b4e11f12a.png)
