### PR TITLE
Fix: remove example for tooltip and add it correctly

### DIFF
--- a/src/docs/components/TipDoc.js
+++ b/src/docs/components/TipDoc.js
@@ -7,12 +7,6 @@ import Anchor from 'grommet/components/Anchor';
 import DocsArticle from '../../components/DocsArticle';
 import Example from '../Example';
 
-const PREAMBLE =
-`<Tip targetId="actions"
-  onClose={() => this.setState({ active: false })}>
-  Available actions
-</Tip>`;
-
 export default class TipDoc extends Component {
 
   constructor () {
@@ -50,7 +44,9 @@ export default class TipDoc extends Component {
         </section>
 
         <section>
-          <Example preamble={PREAMBLE} />
+          <Example
+            code={tip}
+          />
 
           <p>The caller is responsible for determining when to show a Tip.
             The tip should be removed when the <code>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
#### What does this PR do?

This PR fixes a small issue on the documentation site
#### Where should the reviewer start?

Line 47 in `src/docs/components/TipDoc`
#### What testing has been done on this PR?

Manual, by verifying that the code block appears correctly when running the site on localhost.
#### How should this be manually tested?

By running the dev server to verify that the code block for ToolTips is not being cutoff (see screenshots)
#### Any background context you want to provide?

N/A
#### What are the relevant issues?

N/A
#### Screenshots (if appropriate)

**Before:**
![Before](https://cloud.githubusercontent.com/assets/13810084/17934005/426dc2ca-69e4-11e6-8321-9c10e638827b.png)

**After:**
![screen shot 2016-08-24 at 10 20 19 am](https://cloud.githubusercontent.com/assets/13810084/17934052/78c8f6e6-69e4-11e6-9dfc-ca897cb85e1d.png)

Original commit message:
Note: the example was cutting off part of the code
- Following the lead of the rest of the components, this adds the tooltip as a code block using the
  example component
