### PR TITLE
fixing social icon color on Home page, and video paths on CardDoc

### DIFF
--- a/src/Home.js
+++ b/src/Home.js
@@ -115,7 +115,7 @@ export default class Home extends Component {
                 icon={<GithubIcon a11yTitle='Grommet Github' />}/>
               <Anchor href="https://twitter.com/grommetux"
                 icon={<TwitterIcon colorIndex="grey-4"
-                  a11yTitle='Grommet Twitter' />}/>
+                a11yTitle='Grommet Twitter' />}/>
             </Menu>
           </Footer>
         </HomeSection>

--- a/src/Home.js
+++ b/src/Home.js
@@ -114,7 +114,8 @@ export default class Home extends Component {
               <Anchor href="https://github.com/grommet/grommet"
                 icon={<GithubIcon a11yTitle='Grommet Github' />}/>
               <Anchor href="https://twitter.com/grommetux"
-                icon={<TwitterIcon a11yTitle='Grommet Twitter' />}/>
+                icon={<TwitterIcon colorIndex="grey-4"
+                  a11yTitle='Grommet Twitter' />}/>
             </Menu>
           </Footer>
         </HomeSection>

--- a/src/docs/components/CardDoc.js
+++ b/src/docs/components/CardDoc.js
@@ -51,7 +51,7 @@ export default class CardDoc extends Component {
             help you optimize your software investments through control of
             complex negotiations and renewal processes`}
           link={<Anchor href={grommetPath}
-            label="Learn More" icon={<LinkNextIcon />} />}
+          label="Learn More" icon={<LinkNextIcon />} />}
         />
       </Box>
     );
@@ -135,7 +135,7 @@ export default class CardDoc extends Component {
         direction="column"
         label="Featured Post"
         link={<Anchor href={grommetPath} label="Learn More"
-          icon={<LinkNextIcon />} />}>
+        icon={<LinkNextIcon />} />}>
         <Heading tag="h2">
           Protect Your Digital Enterprise ipsum lorem dolores aeat el
         </Heading>
@@ -149,7 +149,7 @@ export default class CardDoc extends Component {
         direction="column"
         label="Featured Post"
         link={<Anchor href={grommetPath} label="Learn More"
-          icon={<LinkNextIcon />} />}>
+        icon={<LinkNextIcon />} />}>
         <Heading tag="h2">
           Protect Your Digital Enterprise ipsum lorem dolores aeat el
         </Heading>
@@ -185,7 +185,7 @@ export default class CardDoc extends Component {
             help you achieve cloud agility with traditional IT
             predictability.`}
           link={<Anchor href={grommetPath} label="Learn More"
-            icon={<LinkNextIcon />} />}
+          icon={<LinkNextIcon />} />}
         />
         <Card
           direction="column"

--- a/src/docs/components/CardDoc.js
+++ b/src/docs/components/CardDoc.js
@@ -50,7 +50,7 @@ export default class CardDoc extends Component {
           description={`HPE Software Licensing and Management Solutions can
             help you optimize your software investments through control of
             complex negotiations and renewal processes`}
-          link={<Anchor href={grommetPath} 
+          link={<Anchor href={grommetPath}
             label="Learn More" icon={<LinkNextIcon />} />}
         />
       </Box>
@@ -67,7 +67,7 @@ export default class CardDoc extends Component {
             solutions to improve quality of life and help eliminate poverty
             in South America.`}
           video={{
-            source: 'video/test.mp4',
+            source: '/video/test.mp4',
             type: 'mp4'
           }}
           link={<Anchor href="#" label="Watch Now" icon={<WatchIcon />} />}
@@ -134,7 +134,7 @@ export default class CardDoc extends Component {
         onClick={this._onClickCard.bind(this, grommetPath)}
         direction="column"
         label="Featured Post"
-        link={<Anchor href={grommetPath} label="Learn More" 
+        link={<Anchor href={grommetPath} label="Learn More"
           icon={<LinkNextIcon />} />}>
         <Heading tag="h2">
           Protect Your Digital Enterprise ipsum lorem dolores aeat el
@@ -148,7 +148,7 @@ export default class CardDoc extends Component {
         thumbnail="/img/carousel-1.png"
         direction="column"
         label="Featured Post"
-        link={<Anchor href={grommetPath} label="Learn More" 
+        link={<Anchor href={grommetPath} label="Learn More"
           icon={<LinkNextIcon />} />}>
         <Heading tag="h2">
           Protect Your Digital Enterprise ipsum lorem dolores aeat el
@@ -196,7 +196,7 @@ export default class CardDoc extends Component {
             solutions to improve quality of life and help eliminate poverty
             in South America.`}
           video={{
-            source: 'video/test.mp4',
+            source: '/video/test.mp4',
             type: 'mp4'
           }}
           link={<Anchor href="#" label="Watch Now" icon={<WatchIcon />} />}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
#### What does this PR do?

Fixes social icon color on Home page (Twitter icon) + video example on CardDoc (to use same video path as VideoDoc example).
#### Screenshots (if appropriate)

![screen shot 2016-08-25 at 4 51 48 pm](https://cloud.githubusercontent.com/assets/10161095/17992560/3f92e746-6ae4-11e6-805f-a080b7f00262.png)
