### PR TITLE
updating CardDoc to use masonry option in Columns + options for Columns, Tiles, Box

### DIFF
--- a/src/docs/components/BoxDoc.js
+++ b/src/docs/components/BoxDoc.js
@@ -43,6 +43,10 @@ export default class BoxDoc extends Component {
             <dt><code>appCentered    true|false</code></dt>
             <dd>Whether the box background should stretch across an App that
               is centered.</dd>
+            <dt><code>basis          {"xsmall|small|medium|large|xlarge|" +
+              "xxlarge|full|1/2|1/3|2/3|1/4|3/4"}</code></dt>
+            <dd>Whether to use a fixed or relative size for the Box's
+              flex-basis.</dd>
             <dt><code>colorIndex     {"{category}-{index}"}</code></dt>
             <dd>The color identifier to use for the background color.
               For example: <code>"neutral-1"</code></dd>
@@ -52,6 +56,8 @@ export default class BoxDoc extends Component {
             <dt><code>focusable      true|false</code></dt>
             <dd>Whether keyboard focus should be added for clickable Boxes.
               Defaults to <code>true</code>.</dd>
+            <dt><code>flex           true|grow|shrink|false</code></dt>
+            <dd>Whether flex-grow and/or flex-shrink is true.</dd>
             <dt><code>full           true|horizontal|vertical|false</code></dt>
             <dd>Whether the width and/or height should take the full viewport
               size.</dd>
@@ -84,13 +90,22 @@ export default class BoxDoc extends Component {
             <dd>Whether children laid out in a row direction should be
               switched to a column layout when the display area narrows.
               Defaults to <code>true</code>.</dd>
-            <dt><code>separator      top|bottom|left|right</code></dt>
+            <dt><code>separator      {"top|bottom|left|right|horizontal|" +
+              "vertical|all|none"}</code></dt>
             <dd>Add a separator.</dd>
-            <dt><code>size           auto|small|medium|large</code></dt>
-            <dd>The width of the Box.  Defaults to <code>auto</code>.</dd>
+            <dt><code>size           {"auto|xsmall|small|medium|large|" +
+              "xlarge|xxlarge|full|{...}"}</code></dt>
+            <dd>The width of the Box.  Defaults to <code>auto</code>.
+              An object can be specified to distinguish width, height (with
+              additional min and max options for width and height). E.g. <code>
+              {"{height: small, " +
+                "width: {max: large}}"}
+              </code>.</dd>
             <dt><code>tag            {"{string}"}</code></dt>
             <dd>The DOM tag to use for the element.
               Defaults to <code>div</code>.</dd>
+            <dt><code>textAlign      left|center|right</code></dt>
+            <dd>Set text-align for the Box contents.</dd>
             <dt><code>texture        {"{string}"}</code></dt>
             <dd>A texture image URL to apply to the background.</dd>
             <dt><code>wrap           true|false</code></dt>

--- a/src/docs/components/CardDoc.js
+++ b/src/docs/components/CardDoc.js
@@ -294,7 +294,8 @@ export default class CardDoc extends Component {
           <Example name="Link, Video, Simple, Simple (Tiles)"
             code={cardTiles} />
 
-          <Example name="Columns (with Masonry, MaxCount 7, and Responsive)" code={cardColumnsMasonry} />
+          <Example name="Columns (with Masonry, MaxCount 7, and Responsive)"
+            code={cardColumnsMasonry} />
         </section>
 
       </DocsArticle>

--- a/src/docs/components/CardDoc.js
+++ b/src/docs/components/CardDoc.js
@@ -8,6 +8,7 @@ import Example from '../Example';
 import Card from 'grommet/components/Card';
 import Anchor from 'grommet/components/Anchor';
 import Box from 'grommet/components/Box';
+import Columns from 'grommet/components/Columns';
 import Tiles from 'grommet/components/Tiles';
 import Heading from 'grommet/components/Heading';
 import SocialTwitterIcon from 'grommet/components/icons/base/SocialTwitter';
@@ -157,7 +158,7 @@ export default class CardDoc extends Component {
     );
 
     let socialCards = (
-      <Tiles size="large" colorIndex="light-2">
+      <Tiles colorIndex="light-2">
         {socialFeedCard1}
         {blogPostCard}
         {socialFeedCard2}
@@ -166,7 +167,7 @@ export default class CardDoc extends Component {
     );
 
     let cardTiles = (
-      <Tiles size="large" colorIndex="light-2">
+      <Tiles colorIndex="light-2">
         <Card
           onClick={this._onClickCard.bind(this, grommetPath)}
           direction="column"
@@ -222,17 +223,19 @@ export default class CardDoc extends Component {
       </Tiles>
     );
 
-    let cardTilesMasonry = (
-      <Tiles size="large" masonry={true} numColumns={7} colorIndex="light-2">
-        {blogPostCard}
-        {featuredPostCard}
-        {socialFeedCard1}
-        {socialFeedCard1}
-        {blogPostCard}
-        {featuredPostCard}
-        {featuredPostCard}
-        {blogPostCard}
-      </Tiles>
+    let cardColumnsMasonry = (
+      <Box colorIndex="light-2">
+        <Columns masonry={true} maxCount={7} responsive={true}>
+          {blogPostCard}
+          {featuredPostCard}
+          {socialFeedCard1}
+          {socialFeedCard1}
+          {blogPostCard}
+          {featuredPostCard}
+          {featuredPostCard}
+          {blogPostCard}
+        </Columns>
+      </Box>
     );
 
     return (
@@ -266,7 +269,8 @@ export default class CardDoc extends Component {
             <dt><code>direction            {'column|row'}</code></dt>
             <dd>Applies the Card in a column (default) or row direction.
             Expects multiple Card modules to be wrapped in
-            a <NavAnchor path="/docs/tiles">Tiles</NavAnchor> component.</dd>
+            a <NavAnchor path="/docs/tiles">Tiles</NavAnchor> or <NavAnchor
+            path="/docs/columns">Columns</NavAnchor> component.</dd>
             <dt><code>reverse              {'true|false'}</code></dt>
             <dd>If thumbnail url is set, align thumbnail to top or bottom of
             card. Defaults to <code>false</code>.</dd>
@@ -290,7 +294,7 @@ export default class CardDoc extends Component {
           <Example name="Link, Video, Simple, Simple (Tiles)"
             code={cardTiles} />
 
-          <Example name="Tiles with Masonry" code={cardTilesMasonry} />
+          <Example name="Columns (with Masonry, MaxCount 7, and Responsive)" code={cardColumnsMasonry} />
         </section>
 
       </DocsArticle>

--- a/src/docs/components/ColumnsDoc.js
+++ b/src/docs/components/ColumnsDoc.js
@@ -2,6 +2,7 @@
 
 import React, { Component } from 'react';
 import DocsArticle from '../../components/DocsArticle';
+import NavAnchor from '../../components/NavAnchor';
 import Example from '../Example';
 import Columns from 'grommet/components/Columns';
 
@@ -24,6 +25,22 @@ export default class ColumnsDoc extends Component {
         <section>
           <h2>Options</h2>
           <dl>
+            <dt><code>justify     start|center|between|end</code></dt>
+            <dd>How to align the contents along the main axis.</dd>
+            <dt><code>masonry     true|false</code></dt>
+            <dd>Whether to fill the columns from left-to-right based on the
+              component width (set by <code>size</code> option). Defaults
+              to <code>false</code>. The max number of columns can be set
+              with <code>maxCount</code>.</dd>
+            <dt><code>maxCount    number</code></dt>
+            <dd>Number of columns to allow for masonry option, based on
+              component width. Responds based on the width of the column
+              children (set with <code>size</code>).</dd>
+            <dt><code>responsive  true|false</code></dt>
+            <dd>Whether masonry columns should collapse into single, full-width column
+              when the display area narrows (to achive similar behavior as
+              responsive <NavAnchor path="/docs/tiles">Tiles</NavAnchor>).
+              Defaults to <code>false</code>.</dd>
             <dt><code>size        small|medium|large</code></dt>
             <dd>The width of each column. Defaults to <code>medium</code>.</dd>
           </dl>

--- a/src/docs/components/ColumnsDoc.js
+++ b/src/docs/components/ColumnsDoc.js
@@ -37,9 +37,9 @@ export default class ColumnsDoc extends Component {
               component width. Responds based on the width of the column
               children (set with <code>size</code>).</dd>
             <dt><code>responsive  true|false</code></dt>
-            <dd>Whether masonry columns should collapse into single, full-width column
-              when the display area narrows (to achive similar behavior as
-              responsive <NavAnchor path="/docs/tiles">Tiles</NavAnchor>).
+            <dd>Whether masonry columns should collapse into single, full-width
+              column when the display area narrows (to achive similar behavior
+              as responsive <NavAnchor path="/docs/tiles">Tiles</NavAnchor>).
               Defaults to <code>false</code>.</dd>
             <dt><code>size        small|medium|large</code></dt>
             <dd>The width of each column. Defaults to <code>medium</code>.</dd>

--- a/src/docs/components/TilesDoc.js
+++ b/src/docs/components/TilesDoc.js
@@ -46,11 +46,13 @@ export default class TileDoc extends Component {
             <dt><code>masonry     true|false</code></dt>
             <dd>Whether to update the number of columns based on the component
               width. Defaults to <code>false</code>. The number of columns can
-              be set with <code>numColumns</code>.</dd>
+              be set with <code>numColumns</code>. Deprecated, use <NavAnchor
+              path="/docs/columns">Columns</NavAnchor> instead.</dd>
             <dt><code>numColumns  number</code></dt>
             <dd>Number of columns to allow for masonry option, based on
               component width. Responds based on the width of the tile children
-              (set with <code>size</code>).</dd>
+              (set with <code>size</code>). Deprecated, use <NavAnchor
+              path="/docs/columns">Columns</NavAnchor> instead.</dd>
           </dl>
           <p>Options for <NavAnchor path="/docs/box">Box</NavAnchor> are
           also available for Tiles.</p>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
#### What does this PR do?
- updating CardDoc to use masonry option in Columns (deprecating masonry in Tiles)
- updating ColumnsDoc with justify, masonry, maxCount, and responsive options
- deprecating masonry and numColumns in TilesDoc
- updating BoxDoc with options: basis, flex, separator, size, textAlign
#### Screenshots (if appropriate)

![screen shot 2016-09-06 at 3 26 48 pm](https://cloud.githubusercontent.com/assets/10161095/18296586/65284026-7446-11e6-883f-99895c2643de.png)
