### PR TITLE
Fix Animation Scroll example jank

### DIFF
--- a/src/docs/Example.js
+++ b/src/docs/Example.js
@@ -2,7 +2,6 @@
 
 import React, { Component,  PropTypes } from 'react';
 import jsxToString from 'jsx-to-string';
-import debounce from 'lodash/debounce';
 import Box from 'grommet/components/Box';
 
 //hjjs configuration
@@ -16,9 +15,7 @@ hljs.registerLanguage('scss', require('highlight.js/lib/languages/scss'));
 export default class Example extends Component {
   constructor (props) {
     super(props);
-    this._highlightCode = props.debounceHighlight
-      ? debounce(this._highlightCode.bind(this), 100)
-      : this._highlightCode.bind(this);
+    this._highlightCode = this._highlightCode.bind(this);
   }
 
   componentDidMount () {
@@ -26,7 +23,12 @@ export default class Example extends Component {
   }
 
   componentDidUpdate () {
-    this._highlightCode();
+    if (this.props.debounceHighlight) {
+      clearTimeout(this._highlightTimer);
+      this._highlightTimer = setTimeout(this._highlightCode, 100);
+    } else {
+      this._highlightCode();
+    }
   }
 
   _highlightCode () {

--- a/src/docs/Example.js
+++ b/src/docs/Example.js
@@ -2,6 +2,7 @@
 
 import React, { Component,  PropTypes } from 'react';
 import jsxToString from 'jsx-to-string';
+import debounce from 'lodash/debounce';
 import Box from 'grommet/components/Box';
 
 //hjjs configuration
@@ -13,12 +14,22 @@ hljs.registerLanguage('javascript',
 hljs.registerLanguage('scss', require('highlight.js/lib/languages/scss'));
 
 export default class Example extends Component {
+  constructor (props) {
+    super(props);
+    this._highlightCode = props.debounceHighlight
+      ? debounce(this._highlightCode.bind(this), 100)
+      : this._highlightCode.bind(this);
+  }
 
   componentDidMount () {
-    hljs.highlightBlock(this.refs.code);
+    this._highlightCode();
   }
 
   componentDidUpdate () {
+    this._highlightCode();
+  }
+
+  _highlightCode () {
     hljs.highlightBlock(this.refs.code);
   }
 
@@ -73,5 +84,6 @@ Example.propTypes = {
   name: PropTypes.string,
   overrides: PropTypes.arrayOf(PropTypes.string),
   preamble: PropTypes.string,
+  debounceHighlight: PropTypes.bool,
   full: PropTypes.oneOf([true, 'horizontal', 'vertical', false])
 };

--- a/src/docs/components/samples/ScrollAnimation.js
+++ b/src/docs/components/samples/ScrollAnimation.js
@@ -3,8 +3,8 @@
 import React, { Component } from 'react';
 import Tiles from 'grommet/components/Tiles';
 import Tile from 'grommet/components/Tile';
-import Box from 'grommet/components/Box';
 import Animate from 'grommet/components/Animate';
+import Box from 'grommet/components/Box';
 import Example from '../../Example';
 
 export default class ScrollAnimation extends Component {
@@ -33,103 +33,54 @@ export default class ScrollAnimation extends Component {
     }
   }
 
+  _renderRow (visible) {
+    return (
+      <Tiles flex={false} fill={true}>
+        <Animate
+          enter={{ animation: 'slide-up', duration: 500, delay: 150 }}
+          leave={{ animation: 'slide-down', duration: 500, delay: 150 }}
+          component={Tile} visible={visible} keep={true}
+          colorIndex="brand" justify="center" align="center"
+          style={{ height: 250 }} size="small"
+        >
+          <h3>1</h3>
+        </Animate>
+        <Animate
+          enter={{ animation: 'slide-up', duration: 500, delay: 300 }}
+          leave={{ animation: 'slide-down', duration: 500, delay: 300 }}
+          component={Tile} visible={visible} keep={true}
+          colorIndex="brand" justify="center" align="center"
+          style={{ height: 250 }} size="small"
+        >
+          <h3>2</h3>
+        </Animate>
+        <Animate
+          enter={{ animation: 'slide-up', duration: 500, delay: 450 }}
+          leave={{ animation: 'slide-down', duration: 500, delay: 450 }}
+          component={Tile} visible={visible} keep={true}
+          colorIndex="brand" justify="center" align="center"
+          style={{ height: 250 }} size="small"
+        >
+          <h3>3</h3>
+        </Animate>
+      </Tiles>
+    );
+  }
+
   render () {
     const { scrollProgress } = this.state;
 
     return (
-      <Example name="Scroll" code={
+      <Example name="Scroll" debounceHighlight code={
         <Box
-          onScroll={this._onScroll}
-          pad="medium" colorIndex="light-2"
+          pad="medium"
+          colorIndex="light-2"
           style={{ maxHeight: 500, overflow: 'auto' }}
+          onScroll={this._onScroll}
         >
-          <Tiles flex={false} fill={true}>
-            <Animate
-              enter={{ animation: 'slide-up', duration: 500, delay: 150 }}
-              leave={{ animation: 'slide-down', duration: 500, delay: 150 }}
-              component={Tile} visible={scrollProgress > 0} keep={true}
-              colorIndex="brand" justify="center" align="center"
-              style={{ height: 250 }}
-            >
-              <h3>1</h3>
-            </Animate>
-            <Animate
-              enter={{ animation: 'slide-up', duration: 500, delay: 300 }}
-              leave={{ animation: 'slide-down', duration: 500, delay: 300 }}
-              component={Tile} visible={scrollProgress > 0} keep={true}
-              colorIndex="brand" justify="center" align="center"
-              style={{ height: 250 }}
-            >
-              <h3>2</h3>
-            </Animate>
-            <Animate
-              enter={{ animation: 'slide-up', duration: 500, delay: 450 }}
-              leave={{ animation: 'slide-down', duration: 500, delay: 450 }}
-              component={Tile} visible={scrollProgress > 0} keep={true}
-              colorIndex="brand" justify="center" align="center"
-              style={{ height: 250 }}
-            >
-              <h3>3</h3>
-            </Animate>
-          </Tiles>
-          <Tiles flex={false} fill={true}>
-            <Animate
-              enter={{ animation: 'slide-up', duration: 500, delay: 150 }}
-              leave={{ animation: 'slide-down', duration: 500, delay: 150 }}
-              component={Tile} visible={scrollProgress > 16} keep={true}
-              colorIndex="brand" justify="center" align="center"
-              style={{ height: 250 }}
-            >
-              <h3>1</h3>
-            </Animate>
-            <Animate
-              enter={{ animation: 'slide-up', duration: 500, delay: 300 }}
-              leave={{ animation: 'slide-down', duration: 500, delay: 300 }}
-              component={Tile} visible={scrollProgress > 16} keep={true}
-              colorIndex="brand" justify="center" align="center"
-              style={{ height: 250 }}
-            >
-              <h3>2</h3>
-            </Animate>
-            <Animate
-              enter={{ animation: 'slide-up', duration: 500, delay: 450 }}
-              leave={{ animation: 'slide-down', duration: 500, delay: 450 }}
-              component={Tile} visible={scrollProgress > 16} keep={true}
-              colorIndex="brand" justify="center" align="center"
-              style={{ height: 250 }}
-            >
-              <h3>3</h3>
-            </Animate>
-          </Tiles>
-          <Tiles flex={false} fill={true}>
-            <Animate
-              enter={{ animation: 'slide-up', duration: 500, delay: 150 }}
-              leave={{ animation: 'slide-down', duration: 500, delay: 150 }}
-              component={Tile} visible={scrollProgress > 32} keep={true}
-              colorIndex="brand" justify="center" align="center"
-              style={{ height: 250 }}
-            >
-              <h3>1</h3>
-            </Animate>
-            <Animate
-              enter={{ animation: 'slide-up', duration: 500, delay: 300 }}
-              leave={{ animation: 'slide-down', duration: 500, delay: 300 }}
-              component={Tile} visible={scrollProgress > 32} keep={true}
-              colorIndex="brand" justify="center" align="center"
-              style={{ height: 250 }}
-            >
-              <h3>2</h3>
-            </Animate>
-            <Animate
-              enter={{ animation: 'slide-up', duration: 500, delay: 450 }}
-              leave={{ animation: 'slide-down', duration: 500, delay: 450 }}
-              component={Tile} visible={scrollProgress > 32} keep={true}
-              colorIndex="brand" justify="center" align="center"
-              style={{ height: 250 }}
-            >
-              <h3>3</h3>
-            </Animate>
-          </Tiles>
+          {this._renderRow(scrollProgress > 0)}
+          {this._renderRow(scrollProgress > 16)}
+          {this._renderRow(scrollProgress > 32)}
         </Box>
       } />
     );


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
#### What does this PR do?

Fix Scroll example in Animation docs page. 
#### Any background context you want to provide?

Currently scrolling in the Animation docs Scroll example is very janky due to `hljs`. 
As you scroll in the example, the `visible` prop changes causing the code block to rerender which will call `hljs.highlightBlock()` every time. 
#### Screenshots (if appropriate)
### Laggy/Janky (without PR)

![scroll-example-jank](https://cloud.githubusercontent.com/assets/3210082/18536358/58841a9a-7a98-11e6-9fd7-2beb824b2c68.gif)
### Smooth (with PR)

![scroll-example-fixed](https://cloud.githubusercontent.com/assets/3210082/18536359/5b394c60-7a98-11e6-8958-511132eefd31.gif)
