### PR TITLE
Fix Stretched Buttons in Docs

### DIFF
--- a/src/docs/components/LayerDoc.js
+++ b/src/docs/components/LayerDoc.js
@@ -130,18 +130,18 @@ export default class LayerDoc extends Component {
         <section>
           <h2>Examples</h2>
 
-          <Example name="Simple, top" control={
+          <Example align="start" name="Simple, top" control={
             <button onClick={this._onOpen.bind(this, 'simple')}>simple</button>
             } code={simpleLayer} />
-          <Example name="Edit, left" control={
+          <Example align="start" name="Edit, left" control={
             <button onClick={this._onOpen.bind(this, 'edit')}>edit</button>
             } code={editLayer} />
-          <Example name="Confirmation, right" control={
+          <Example align="start" name="Confirmation, right" control={
             <button onClick={this._onOpen.bind(this, 'confirmation')}>
               confirmation
             </button>
             } code={confirmationLayer} />
-          <Example name="Article, center" control={
+          <Example align="start" name="Article, center" control={
             <button onClick={this._onOpen.bind(this, 'article')}>edit</button>
             } code={articleLayer} />
         </section>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
#### What does this PR do?

Updating LayerDoc to fix stretched Buttons in examples (default align-items = stretch instead of flex-start).
#### Any background context you want to provide?

Checked button widths in other component doc pages (including Button doc), and buttons appear stretched only in Layer doc.

Flexbox container wrapping Button needs to have `align-items = flex-start` instead of default `stretch` value.
#### What are the relevant issues?

https://github.com/grommet/grommet-docs/issues/79
#### Screenshots (if appropriate)

![screen shot 2016-09-19 at 10 00 05 am](https://cloud.githubusercontent.com/assets/10161095/18647282/f95196bc-7e50-11e6-9304-bc063787591d.png)
Fixed button widths.
