### PR TITLE
resolving forEach/NodeList IE11 error

### DIFF
--- a/src/components/DocsArticle.js
+++ b/src/components/DocsArticle.js
@@ -38,7 +38,10 @@ export default class DocsArticle extends Component {
   }
 
   _highlightCode () {
-    var codeBlocks = document.querySelectorAll('code.html.xml.hljs');
+    const codeBlockNodeList = document.querySelectorAll('code.html.xml.hljs');
+    // IE11 errors out when attempting to call forEach on array-like object
+    const codeBlocks = Array.prototype.slice.call(codeBlockNodeList);
+
     codeBlocks.forEach((codeBlock) => {
       hljs.highlightBlock(codeBlock);
     });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
#### What does this PR do?

resolving NodeList/forEach error in IE11 preventing Docs page from loading
#### What testing has been done on this PR?

Tested in IE11.
#### Any background context you want to provide?

See screenshot for previous IE11 console error.
#### Screenshots (if appropriate)

IE11 error:
![screen shot 2016-09-19 at 11 35 44 am](https://cloud.githubusercontent.com/assets/10161095/18650309/2331194e-7e60-11e6-9137-308297ea3c03.png)
