### PR TITLE
Fix `/docs/icon` path in Anchor docs

### DIFF
--- a/src/components/NavAnchor.js
+++ b/src/components/NavAnchor.js
@@ -23,7 +23,7 @@ export default class NavAnchor extends Component {
   }
 
   render () {
-    const { path } = this.props;
+    const { path, ...props } = this.props;
     const { router } = this.context;
     let className = this.props.className || '';
     if (router.isActive(path)) {
@@ -31,7 +31,7 @@ export default class NavAnchor extends Component {
     }
     let href = router.createPath(path);
     return (
-      <Anchor {...this.props} className={className} href={href}
+      <Anchor {...props} className={className} href={href}
         onClick={this._onClick} />
     );
   }

--- a/src/docs/components/anchor/AnchorDoc.js
+++ b/src/docs/components/anchor/AnchorDoc.js
@@ -53,7 +53,7 @@ export default class AnchorDoc extends Component {
             <dd>Hyperlink reference to place in the anchor.</dd>
             <dt><code>icon           {"{element}"}</code></dt>
             <dd>Icon element to place in the anchor.
-              See <NavAnchor path="/develop/icon">Icon</NavAnchor>.</dd>
+              See <NavAnchor path="/docs/icon">Icon</NavAnchor>.</dd>
             <dt><code>label          {"{string}"}</code></dt>
             <dd>Label text to place in the anchor.</dd>
             <dt><code>onClick        {"{function}"}</code></dt>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
#### What does this PR do?

Fix `/docs/icon` path in Anchor docs.
Transfer props to Anchor without `path`.
#### What testing has been done on this PR?

Tested on Anchor docs page.
#### What are the relevant issues?

https://github.com/grommet/grommet/pull/899
