### PR TITLE
Updated IE11 browser support copy.

### DIFF
--- a/src/docs/reference/BrowserSupport.js
+++ b/src/docs/reference/BrowserSupport.js
@@ -30,8 +30,8 @@ export default class BrowserSupport extends Component {
           <h2>Supported web browsers and versions</h2>
           <p>The following web browsers are tested and supported with
             Grommet.</p>
-          <Browser icon={IEIcon}>Microsoft Internet Explorer Version 11
-          </Browser>
+          <Browser icon={IEIcon}>Microsoft Internet Explorer Version 11,
+           latest version</Browser>
           <Browser icon={EdgeIcon}>Microsoft Edge, latest version</Browser>
           <Browser icon={FirefoxIcon}>Mozilla Firefox, latest version</Browser>
           <Browser icon={ChromeIcon}>


### PR DESCRIPTION
Updates IE11 browser support text to include `latest version`. Early versions of IE11 do not properly support Grommet's Box component. I've researched when the finalized flexbox spec was added to IE11 and can not discern an exact version. I can, however, confirm flexbox does not work properly with IE11's 2013 releases.
