### PR TITLE
FormDoc: Fix Button clipped on IE11 within Footer component

### DIFF
--- a/src/docs/components/form/FormDoc.js
+++ b/src/docs/components/form/FormDoc.js
@@ -6,6 +6,7 @@ import Header from 'grommet/components/Header';
 import Footer from 'grommet/components/Footer';
 import FormFields from 'grommet/components/FormFields';
 import FormField from 'grommet/components/FormField';
+import Menu from 'grommet/components/Menu';
 import Button from 'grommet/components/Button';
 import DocsArticle from '../../../components/DocsArticle';
 import NavAnchor from '../../../components/NavAnchor';
@@ -66,8 +67,10 @@ export default class FormDoc extends Component {
               </fieldset>
             </FormFields>
             <Footer pad={{vertical: 'medium'}}>
-              <Button label="Submit" primary={true}
-                onClick={() => alert('submit')} />
+              <Menu>
+                <Button label="Submit" primary={true}
+                  onClick={() => alert('submit')} />
+              </Menu>
             </Footer>
           </Form>
         </section>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
#### What does this PR do?

In IE11, `Button` is getting clipped within `Footer` component due to the set height on `.grommetux-footer`. Wrapping it in a `Menu` component fixes this problem.

Related to https://github.com/grommet/grommet/issues/974.
#### What testing has been done on this PR?

Tested on https://grommet.github.io/hpe/docs/form/
