### PR TITLE
Added additional Hero examples.

### DIFF
--- a/src/docs/components/hero/HeroExamplesDoc.js
+++ b/src/docs/components/hero/HeroExamplesDoc.js
@@ -3,9 +3,12 @@
 import React from 'react';
 import Hero from 'grommet/components/Hero';
 import Video from 'grommet/components/Video';
+import Box from 'grommet/components/Box';
+import Card from 'grommet/components/Card';
 import Anchor from 'grommet/components/Anchor';
 import ExamplesDoc from '../../../components/ExamplesDoc';
 import Example from '../../Example';
+import HeroCardVideoLayer from './examples/HeroCardVideoLayer';
 
 const HeroExample = (props) => (
   <Example code={
@@ -19,8 +22,17 @@ HeroExamplesDoc.defaultProps = {
   context: <Anchor path="/docs/hero">Hero</Anchor>,
   examples: [
     { label: 'Default', component: HeroExample, props: {
-      backgroundType: 'image', backgroundImage: '/img/carousel-1.png',
+      backgroundImage: '/img/carousel-1.png',
       children: <h1>You are my Hero</h1>
+    } },
+    { label: 'Card', component: HeroExample, props: {
+      size: 'small', backgroundImage: '/img/carousel-1.png',
+      children: 
+        <Box colorIndex="grey-1-a">
+          <Card heading="Heading" description="Hero description text." 
+          label="label" 
+          link={<Anchor href="#" primary={true} label="Link" />} />
+        </Box>
     } },
     { label: 'Video', component: HeroExample, props: {
       size: 'small', backgroundVideo: (
@@ -29,7 +41,8 @@ HeroExamplesDoc.defaultProps = {
         </Video>
       ),
       children: <h1>A Hero with video</h1>
-    } }
+    } },
+    { label: 'Card with Video Layer', component: HeroCardVideoLayer }
   ],
   title: 'Examples'
 };

--- a/src/docs/components/hero/examples/HeroCardVideoLayer.js
+++ b/src/docs/components/hero/examples/HeroCardVideoLayer.js
@@ -1,0 +1,58 @@
+import React, { Component } from 'react';
+import Box from 'grommet/components/Box';
+import Card from 'grommet/components/Card';
+import Anchor from 'grommet/components/Anchor';
+import Hero from 'grommet/components/Hero';
+import Layer from 'grommet/components/Layer';
+import Video from 'grommet/components/Video';
+import CirclePlayIcon from 'grommet/components/icons/base/CirclePlay';
+import Example from '../../../Example';
+
+export default class HeroCardVideoLayer extends Component {
+  constructor() {
+    super();
+
+    this.state = {
+      layerActive: false
+    };
+
+    this._toggleLayer = this._toggleLayer.bind(this);
+  }
+
+  _toggleLayer() {
+    this.setState({ layerActive: !this.state.layerActive });
+  }
+
+  _renderHero(nodeToInsert) {
+    return (
+      <Hero backgroundImage="/img/carousel-1.png">
+        <Box colorIndex="grey-1-a">
+          <Card heading="Heading" description="Hero description text." 
+            label="label" 
+            link={<Anchor href="#" primary={true} label="Watch Now" 
+              icon={<CirclePlayIcon />} onClick={this._toggleLayer} />} />
+        </Box>
+        {nodeToInsert}
+      </Hero>
+    );
+  }
+
+  render() {
+    const layer = (
+      <Layer closer={true} onClose={this._toggleLayer}>
+        <Box pad="large">
+          <Video autoPlay={true} loop={true} muted={true}>
+            <source src="/video/test.mp4" type="video/mp4"/>
+          </Video>
+        </Box>
+      </Layer>
+    );
+    const codeHero = this._renderHero(layer);
+    const layerNode = this.state.layerActive ? layer : undefined;
+    const controlHero = this._renderHero(layerNode);
+
+    return (
+      <Example control={controlHero} code={codeHero} />
+    );
+  }
+};


### PR DESCRIPTION
#### What does this PR do?

This PR adds two additional examples to the Hero component documentation examples. The PR includes examples for using Hero with a Card component as well as a Hero with a combination of Card/Layer/Video.
#### Where should the reviewer start?

The examples can be reviewed and tested by in this grommet-docs branch.
#### What testing has been done on this PR?

These examples have been tested in the grommet-docs development environment on desktop and mobile.
#### Any background context you want to provide?

These examples are inspired by the digital toolkit Marquee component.
#### What are the relevant issues?

None.
#### Screenshots (if appropriate)
# Card (desktop)

![screen shot 2016-10-22 at 12 12 25 pm](https://cloud.githubusercontent.com/assets/5983843/19620705/e0ba4396-9850-11e6-9789-732e964dee73.png)
# Card (Mobile)

![screen shot 2016-10-22 at 12 12 34 pm](https://cloud.githubusercontent.com/assets/5983843/19620706/e81be8e2-9850-11e6-8c17-d2b8d3329034.png)
# Card with Video Layer

![screen shot 2016-10-22 at 12 12 01 pm](https://cloud.githubusercontent.com/assets/5983843/19620714/f5114c0e-9850-11e6-8172-a86e83fca05b.png)
![screen shot 2016-10-22 at 12 12 10 pm](https://cloud.githubusercontent.com/assets/5983843/19620715/f8dcd47a-9850-11e6-810e-175a5aa473f8.png)
