### PR TITLE
Pulse: update import path (closes grommet/grommet#1011)

### DIFF
--- a/src/docs/components/PulseDoc.js
+++ b/src/docs/components/PulseDoc.js
@@ -10,7 +10,7 @@ import Example from '../Example';
 Pulse.displayName = 'Pulse';
 
 const USAGE =
-`import Pulse from 'grommet/components/Pulse';
+`import Pulse from 'grommet/components/icons/Pulse';
 <Pulse />`;
 
 export default class PulseDoc extends Component {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
#### What does this PR do?

Updates the usage of the `import` path for the Pulse icon.
#### What are the relevant issues?

grommet/grommet#1011
