### PR TITLE
document the Spinner size property from grommet PR #1172

### DIFF
--- a/src/docs/components/SpinningDoc.js
+++ b/src/docs/components/SpinningDoc.js
@@ -23,6 +23,14 @@ export default class SpinningDoc extends Component {
         </section>
 
         <section>
+          <h2>Properties</h2>
+          <dl>
+            <dt><code>size         small|medium|large|xlarge|huge</code></dt>
+            <dd>The icon size.  Defaults to <code>medium</code>.</dd>
+          </dl>
+        </section>
+
+        <section>
           <h2>Usage</h2>
           <Code preamble={
             `import Spinning from 'grommet/components/icons/Spinning';`}>


### PR DESCRIPTION
This documents the change in [grommet PR #1172](https://github.com/grommet/grommet/pull/1172)

Signed-off-by: Cullan Springstead <cullan.springstead@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
It adds the size property to the documentation for the Spinner component.

#### What testing has been done on this PR?
I made the change, ran the dev server, and looked at the page.