### PR TITLE
Add missing max prop in AnnotatedMeterDoc #265 

### DIFF
--- a/src/docs/components/annotated-meter/AnnotatedMeterDoc.js
+++ b/src/docs/components/annotated-meter/AnnotatedMeterDoc.js
@@ -38,11 +38,11 @@ export default class AnnotatedMeterDoc extends Component {
             with a <Anchor path='/docs/value'>Value</Anchor> and
             optional <Anchor path='/docs/legend'>Legend</Anchor>.</p>
           <Box direction='row' align='center' pad={{ between: 'large' }}>
-            <AnnotatedMeter type='bar' series={[
+            <AnnotatedMeter type='bar' max={70} series={[
               { label: 'First', value: 20 },
               { label: 'Second', value: 50 }
             ]} />
-            <AnnotatedMeter type='circle' series={[
+            <AnnotatedMeter type='circle' max={70} series={[
               { label: 'First', value: 20 },
               { label: 'Second', value: 50 }
             ]} />
@@ -82,7 +82,7 @@ export default class AnnotatedMeterDoc extends Component {
           <h2>Example</h2>
 
           <Example code={
-            <AnnotatedMeter type='circle' series={[
+            <AnnotatedMeter type='circle' max={70} series={[
               { label: 'First', value: 20 },
               { label: 'Second', value: 50 }
             ]} legend={true} />

--- a/src/docs/components/annotated-meter/AnnotatedMeterExamplesDoc.js
+++ b/src/docs/components/annotated-meter/AnnotatedMeterExamplesDoc.js
@@ -24,7 +24,7 @@ export default class AnnotatedMeterExamplesDoc extends Component {
       elementProps.type = 'bar';
     }
     const element = (
-      <AnnotatedMeter {...elementProps} series={[
+      <AnnotatedMeter {...elementProps} max={70} series={[
         { label: 'First', value: 20 },
         { label: 'Second', value: 50 }
       ]} />


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes AnnotatedMeter examples which were missing `max` props (And max was defaulting to 100). Issie #265 
#### Where should the reviewer start?
https://grommet.github.io/docs/annotated-meter
