### PR TITLE
Fix meter docs to include size xlarge #268

### DIFF
--- a/src/docs/components/meter/MeterDoc.js
+++ b/src/docs/components/meter/MeterDoc.js
@@ -70,7 +70,7 @@ export default class MeterDoc extends Component {
               Either this or the <code>value</code> property must be
               provided. The <code>spiral</code> type Meter also accepts a
               <code>label</code> property for the objects in the series.</dd>
-            <dt><code>size        xsmall|small|medium|large</code></dt>
+            <dt><code>size        xsmall|small|medium|large|xlarge</code></dt>
             <dd>The size of the Meter. Defaults to <code>medium</code>.
               Currently, the <code>spiral</code> type Meter does not respond
               to this property.</dd>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fix meter docs to include supported size ```xlarge```
#### Where should the reviewer start?
https://grommet.github.io/hpe/docs/meter
