### PR TITLE
Fixes #1395 - some FormField props aren't documented.

### DIFF
--- a/src/docs/components/form-field/FormFieldDoc.js
+++ b/src/docs/components/form-field/FormFieldDoc.js
@@ -46,8 +46,18 @@ export default class FormFieldDoc extends Component {
           <dt><code>htmlFor   {'{string}'}</code></dt>
           <dd>Id of the input element that the label should be associated
             with.</dd>
+          <dt><code>hidden     {'true|false'}</code></dt>
+          <dd>Whether the FormField should be hidden. Defaults to <code>false</code>.
+              This property will most likely be removed in Grommet 2.0. Consider using 
+              React state to manage the FormFields you want to show/hide.</dd>
           <dt><code>label     {'{string|node}'}</code></dt>
           <dd>Label for the field.</dd>
+          <dt><code>size     {'medium|large'}</code></dt>
+          <dd>The size of the input text font. Defaults to <code>medium</code>.
+              This property will most likely be removed in Grommet 2.0.</dd>
+          <dt><code>strong     {'true|false'}</code></dt>
+          <dd>Whether the text for the input field should be strong. Defaults to <code>false</code>. 
+              This property will most likely be removed in Grommet 2.0.</dd>
           </dl>
         </section>
 

--- a/src/docs/components/form-field/FormFieldDoc.js
+++ b/src/docs/components/form-field/FormFieldDoc.js
@@ -47,17 +47,19 @@ export default class FormFieldDoc extends Component {
           <dd>Id of the input element that the label should be associated
             with.</dd>
           <dt><code>hidden     {'true|false'}</code></dt>
-          <dd>Whether the FormField should be hidden. Defaults to <code>false</code>.
-              This property will most likely be removed in Grommet 2.0. Consider using 
-              React state to manage the FormFields you want to show/hide.</dd>
+          <dd>Whether the FormField should be hidden. Defaults 
+              to <code>false</code>. This property will most likely be removed 
+              in Grommet 2.0. Consider using React state to manage the 
+              FormFields you want to show/hide.</dd>
           <dt><code>label     {'{string|node}'}</code></dt>
           <dd>Label for the field.</dd>
           <dt><code>size     {'medium|large'}</code></dt>
           <dd>The size of the input text font. Defaults to <code>medium</code>.
               This property will most likely be removed in Grommet 2.0.</dd>
           <dt><code>strong     {'true|false'}</code></dt>
-          <dd>Whether the text for the input field should be strong. Defaults to <code>false</code>. 
-              This property will most likely be removed in Grommet 2.0.</dd>
+          <dd>Whether the text for the input field should be strong. Defaults 
+              to <code>false</code>. This property will most likely be removed 
+              in Grommet 2.0.</dd>
           </dl>
         </section>
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds documentation for the hidden, size and strong properties of the FormField component.

#### Where should the reviewer start?
Line 49 of FormFieldDoc.js.

#### What testing has been done on this PR?
Manual testing of the changes in my sandbox.

#### How should this be manually tested?
Pull the change into your sandbox and build grommet.io. Browse to the FormField component page and find the properties that were added.

#### Any background context you want to provide?
This documents the properties as they are currently used (i.e. for input text in a FormField). 

#### What are the relevant issues?
Support for these properties will most likely be removed in Grommet 2.0.

#### Screenshots (if appropriate)
