### PR TITLE
Fix for #272 - Improve documentation for Tab component

### DIFF
--- a/src/docs/components/form-field/FormFieldDoc.js
+++ b/src/docs/components/form-field/FormFieldDoc.js
@@ -46,8 +46,18 @@ export default class FormFieldDoc extends Component {
           <dt><code>htmlFor   {'{string}'}</code></dt>
           <dd>Id of the input element that the label should be associated
             with.</dd>
+          <dt><code>hidden     {'true|false'}</code></dt>
+          <dd>Whether the FormField should be hidden. Defaults to <code>false</code>.
+              This property will most likely be removed in Grommet 2.0. Consider using 
+              React state to manage the FormFields you want to show/hide.</dd>
           <dt><code>label     {'{string|node}'}</code></dt>
           <dd>Label for the field.</dd>
+          <dt><code>size     {'medium|large'}</code></dt>
+          <dd>The size of the input text font. Defaults to <code>medium</code>.
+              This property will most likely be removed in Grommet 2.0.</dd>
+          <dt><code>strong     {'true|false'}</code></dt>
+          <dd>Whether the text for the input field should be strong. Defaults to <code>false</code>. 
+              This property will most likely be removed in Grommet 2.0.</dd>
           </dl>
         </section>
 

--- a/src/docs/components/form-field/FormFieldDoc.js
+++ b/src/docs/components/form-field/FormFieldDoc.js
@@ -47,17 +47,19 @@ export default class FormFieldDoc extends Component {
           <dd>Id of the input element that the label should be associated
             with.</dd>
           <dt><code>hidden     {'true|false'}</code></dt>
-          <dd>Whether the FormField should be hidden. Defaults to <code>false</code>.
-              This property will most likely be removed in Grommet 2.0. Consider using 
-              React state to manage the FormFields you want to show/hide.</dd>
+          <dd>Whether the FormField should be hidden. Defaults 
+              to <code>false</code>. This property will most likely be removed 
+              in Grommet 2.0. Consider using React state to manage the 
+              FormFields you want to show/hide.</dd>
           <dt><code>label     {'{string|node}'}</code></dt>
           <dd>Label for the field.</dd>
           <dt><code>size     {'medium|large'}</code></dt>
           <dd>The size of the input text font. Defaults to <code>medium</code>.
               This property will most likely be removed in Grommet 2.0.</dd>
           <dt><code>strong     {'true|false'}</code></dt>
-          <dd>Whether the text for the input field should be strong. Defaults to <code>false</code>. 
-              This property will most likely be removed in Grommet 2.0.</dd>
+          <dd>Whether the text for the input field should be strong. Defaults 
+              to <code>false</code>. This property will most likely be removed 
+              in Grommet 2.0.</dd>
           </dl>
         </section>
 

--- a/src/docs/components/hero/HeroExamplesDoc.js
+++ b/src/docs/components/hero/HeroExamplesDoc.js
@@ -109,7 +109,7 @@ export default class HeroExamplesDoc extends Component {
     return (
       <InteractiveExample contextLabel='Hero' contextPath='/docs/hero'
         align='stretch'
-        preamble={`import Header from 'grommet/components/Hero';`}
+        preamble={`import Hero from 'grommet/components/Hero';`}
         propsSchema={PROPS_SCHEMA}
         contentsSchema={CONTENTS_SCHEMA}
         element={element} onChange={this._onChange} />

--- a/src/docs/components/tabs/TabsDoc.js
+++ b/src/docs/components/tabs/TabsDoc.js
@@ -17,7 +17,8 @@ export default class TabsDoc extends Component {
       }>
 
         <section>
-          <p>A tabular view component.</p>
+          <p>A tabular view component. The Tabs component contains one or more 
+             Tab components.</p>
           <Tabs>
           <Tab title='First Title'>
             <Paragraph>First contents</Paragraph>
@@ -29,7 +30,7 @@ export default class TabsDoc extends Component {
         </section>
 
         <section>
-          <h2>Properties</h2>
+          <h2>Tabs Properties</h2>
           <dl>
             <dt><code>activeIndex         {'{number}'}</code></dt>
             <dd>Active tab index. Defaults to 0.</dd>
@@ -44,6 +45,15 @@ export default class TabsDoc extends Component {
               switched to a centered column layout when the display
               area narrows.
               Defaults to <code>true</code>.</dd>
+          </dl>
+        </section>
+
+        <section>
+          <h2>Tab Properties</h2>
+          <dl>
+            <dt><code>title        {'{string}'}</code></dt>
+            <dd>Label for the tab. This property is required. </dd>
+            
           </dl>
         </section>
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Added a new Tab Properties section to the Tabs doc page.

Also, made a  minor, unrelated fix to the preamble for the Hero examples doc page.

#### Where should the reviewer start?
Line 20 of TabsDoc.js for the new Tab Properties changes.

Line 112 of HeroExamplesDoc.js for the Hero examples fix.

#### What testing has been done on this PR?
Deployed these changes to my sandbox and browsed to the Tabs page and Hero Examples page using both Chrome and IE11.

#### How should this be manually tested?
See item above.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
