### PR TITLE
Add deprecation notice to Card's description.

### DIFF
--- a/src/docs/components/card/CardDoc.js
+++ b/src/docs/components/card/CardDoc.js
@@ -51,10 +51,11 @@ export default class CardDoc extends Component {
               </code></dt>
             <dd>Either a string in markdown syntax or an element.
               See <Anchor path='/docs/markdown'>
-              Markdown</Anchor> for additional details. <strong>Deprecation Notice: </strong>
-              Implicit Markdown support will be removed in the next major release.
-              Description will continue to accept elements as a description
-              property.</dd>
+              Markdown</Anchor> for additional details.
+              <strong>Deprecation Notice: </strong>
+              Implicit Markdown support will be removed in the next major 
+              release.Description will continue to accept elements as a
+              description property.</dd>
             <dt><code>heading              {'{string}|{element}'}</code></dt>
             <dd>Heading content.</dd>
             <dt><code>headingStrong        true|false</code></dt>

--- a/src/docs/components/card/CardDoc.js
+++ b/src/docs/components/card/CardDoc.js
@@ -51,7 +51,10 @@ export default class CardDoc extends Component {
               </code></dt>
             <dd>Either a string in markdown syntax or an element.
               See <Anchor path='/docs/markdown'>
-              Markdown</Anchor> for additional details.</dd>
+              Markdown</Anchor> for additional details. <strong>Deprecation Notice: </strong>
+              Implicit Markdown support will be removed in the next major release.
+              Description will continue to accept elements as a description
+              property.</dd>
             <dt><code>heading              {'{string}|{element}'}</code></dt>
             <dd>Heading content.</dd>
             <dt><code>headingStrong        true|false</code></dt>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds a deprecation notice to the Card docs. Note: I can target a release if we know which release we'd like to remove Card's markdown support.

```
Deprecation Notice: Implicit Markdown support will be removed in the next major release. 
Description will continue to accept elements as a description
```

#### What are the relevant issues?
Grommet Issue [#1550](https://github.com/grommet/grommet/issues/1550)

#### Screenshots (if appropriate)
![screen shot 2017-09-05 at 4 28 23 pm](https://user-images.githubusercontent.com/5983843/30082050-6bf0a76a-9257-11e7-87bb-fb8f9563bfa2.png)
